### PR TITLE
Balance changes

### DIFF
--- a/Content/Bosses/EoC/EoC.cs
+++ b/Content/Bosses/EoC/EoC.cs
@@ -106,7 +106,7 @@ public class EoC : AcidicNPCOverride
     private void EnterPhaseOne()
     {
         var hover = new AttackState(() => Attack_Hover(180, 7.5f, 0.05f, 250f), 0);
-        var dash = new AttackState(() => Attack_DashAtPlayer(30, 7.5f, false) == DashState.Done, 45);
+        var dash = new AttackState(() => Attack_DashAtPlayer(30, 7.5f, false, 250) == DashState.Done, 45);
         var summon = new AttackState(() => Attack_SummonMinions(3), 15);
 
         AttackManager.SetAttackPattern([
@@ -144,7 +144,7 @@ public class EoC : AcidicNPCOverride
     {
         var hover = new AttackState(() => Attack_Hover(120, 10f, 0.15f, 250f), 0);
         var telegraphedDash = new AttackState(() => Attack_TelegraphedDash(45, 15f), 15);
-        var dash = new AttackState(() => Attack_DashAtPlayer(45, 15f, true) == DashState.Done, 15);
+        var dash = new AttackState(() => Attack_DashAtPlayer(45, 15f, true, 250) == DashState.Done, 15);
         var teleport = new AttackState(Attack_TeleportBehind, 15);
         
         AttackManager.SetAttackPattern([
@@ -391,16 +391,14 @@ public class EoC : AcidicNPCOverride
         Done
     }
 
-    private DashState Attack_DashAtPlayer(int dashLength, float speed, bool enraged)
+    private DashState Attack_DashAtPlayer(int dashLength, float speed, bool enraged, float distance)
     {
-        const float minDistForDash = 300;
-        
         AttackManager.CountUp = true;
         var target = Main.player[Npc.target];
 
         // Don't dash while too close to the player
         // Back away until it's far enough
-        if (Npc.Distance(target.Center + target.velocity * dashTrackTime * 0.5f) < minDistForDash && AttackManager.AiTimer < dashTrackTime)
+        if (Npc.Distance(target.Center + target.velocity * dashTrackTime * 0.5f) < distance && AttackManager.AiTimer < dashTrackTime)
         {
             AttackManager.AiTimer = -1;
             Npc.SimpleFlyMovement(-Npc.DirectionTo(target.Center) * 10f, 0.5f);
@@ -439,7 +437,7 @@ public class EoC : AcidicNPCOverride
         AttackManager.CountUp = true;
 
         // Normal dash movement
-        var dashState = Attack_DashAtPlayer(dashLength, speed, true);
+        var dashState = Attack_DashAtPlayer(dashLength, speed, true, 300);
 
         if (dashState == DashState.Repositioning) return false;
 
@@ -460,14 +458,14 @@ public class EoC : AcidicNPCOverride
         AttackManager.CountUp = true;
 
         // Dash Normally for self
-        var dashState = Attack_DashAtPlayer(dashLength, speed, true);
+        var dashState = Attack_DashAtPlayer(dashLength, speed, true, 500);
 
         if (dashState == DashState.Repositioning) return false;
 
         if (dashState == DashState.Done) AttackManager.CountUp = false;
         if (Main.netMode == NetmodeID.MultiplayerClient) return dashState == DashState.Done;
 
-        const float dashOffset = MathHelper.Pi / 6f;
+        const float dashOffset = MathHelper.Pi / 5f;
 
         // Triple Telegraphs
         for (var i = 0; i < 3; i++)

--- a/Content/Bosses/EoC/EoC.cs
+++ b/Content/Bosses/EoC/EoC.cs
@@ -106,7 +106,7 @@ public class EoC : AcidicNPCOverride
     private void EnterPhaseOne()
     {
         var hover = new AttackState(() => Attack_Hover(180, 7.5f, 0.05f, 250f), 0);
-        var dash = new AttackState(() => Attack_DashAtPlayer(30, 7.5f, false), 45);
+        var dash = new AttackState(() => Attack_DashAtPlayer(30, 7.5f, false) == DashState.Done, 45);
         var summon = new AttackState(() => Attack_SummonMinions(3), 15);
 
         AttackManager.SetAttackPattern([
@@ -144,7 +144,7 @@ public class EoC : AcidicNPCOverride
     {
         var hover = new AttackState(() => Attack_Hover(120, 10f, 0.15f, 250f), 0);
         var telegraphedDash = new AttackState(() => Attack_TelegraphedDash(45, 15f), 15);
-        var dash = new AttackState(() => Attack_DashAtPlayer(45, 15f, true), 15);
+        var dash = new AttackState(() => Attack_DashAtPlayer(45, 15f, true) == DashState.Done, 15);
         var teleport = new AttackState(Attack_TeleportBehind, 15);
         
         AttackManager.SetAttackPattern([
@@ -383,17 +383,39 @@ public class EoC : AcidicNPCOverride
     private static int dashTrackTime = 15;
     private static int dashAtTime = 30;
 
-    private bool Attack_DashAtPlayer(int dashLength, float speed, bool enraged)
+    enum DashState
     {
+        Repositioning,
+        Tracking,
+        Dashing,
+        Done
+    }
+
+    private DashState Attack_DashAtPlayer(int dashLength, float speed, bool enraged)
+    {
+        const float minDistForDash = 300;
+        
         AttackManager.CountUp = true;
-        var target = Main.player[Npc.target].Center;
+        var target = Main.player[Npc.target];
+
+        // Don't dash while too close to the player
+        // Back away until it's far enough
+        if (Npc.Distance(target.Center + target.velocity * dashTrackTime * 0.5f) < minDistForDash && AttackManager.AiTimer < dashTrackTime)
+        {
+            AttackManager.AiTimer = -1;
+            Npc.SimpleFlyMovement(-Npc.DirectionTo(target.Center) * 10f, 0.5f);
+            LookTowards(target.Center, 0.25f);
+            return DashState.Repositioning;
+        }
 
         if (AttackManager.AiTimer < dashTrackTime)
         {
             Npc.SimpleFlyMovement(Vector2.Zero, 0.75f);
-            LookTowards(target, 0.25f);
+            LookTowards(target.Center, 0.25f);
+            return DashState.Tracking;
         }
-        else if (AttackManager.AiTimer == dashAtTime)
+
+        if (AttackManager.AiTimer == dashAtTime)
         {
             Npc.velocity = (Npc.rotation + MathHelper.PiOver2).ToRotationVector2() * speed;
             if (enraged)
@@ -406,10 +428,10 @@ public class EoC : AcidicNPCOverride
         {
             AttackManager.CountUp = false;
             useAfterimages = false;
-            return true;
+            return DashState.Done;
         }
 
-        return false;
+        return DashState.Dashing;
     }
 
     private bool Attack_TelegraphedDash(int dashLength, float speed)
@@ -417,10 +439,12 @@ public class EoC : AcidicNPCOverride
         AttackManager.CountUp = true;
 
         // Normal dash movement
-        var isDone = Attack_DashAtPlayer(dashLength, speed, true);
+        var dashState = Attack_DashAtPlayer(dashLength, speed, true);
 
-        if (isDone) AttackManager.CountUp = false;
-        if (Main.netMode == NetmodeID.MultiplayerClient) return isDone;
+        if (dashState == DashState.Repositioning) return false;
+
+        if (dashState == DashState.Done) AttackManager.CountUp = false;
+        if (Main.netMode == NetmodeID.MultiplayerClient) return dashState == DashState.Done;
 
         // Create Telegraph
         if (AttackManager.AiTimer == 0)
@@ -428,7 +452,7 @@ public class EoC : AcidicNPCOverride
             var line = NewDashLine(Npc.Center, MathHelper.PiOver2, dashAtTime);
         }
 
-        return isDone;
+        return dashState == DashState.Done;
     }
 
     private bool Attack_TripleDash(int dashLength, float speed)
@@ -436,10 +460,12 @@ public class EoC : AcidicNPCOverride
         AttackManager.CountUp = true;
 
         // Dash Normally for self
-        var isDone = Attack_DashAtPlayer(dashLength, speed, true);
+        var dashState = Attack_DashAtPlayer(dashLength, speed, true);
 
-        if (isDone) AttackManager.CountUp = false;
-        if (Main.netMode == NetmodeID.MultiplayerClient) return isDone;
+        if (dashState == DashState.Repositioning) return false;
+
+        if (dashState == DashState.Done) AttackManager.CountUp = false;
+        if (Main.netMode == NetmodeID.MultiplayerClient) return dashState == DashState.Done;
 
         const float dashOffset = MathHelper.Pi / 6f;
 
@@ -458,7 +484,7 @@ public class EoC : AcidicNPCOverride
         }
 
         // The phantom eye stuff is owned by server
-        if (Main.netMode == NetmodeID.MultiplayerClient) return isDone;
+        if (Main.netMode == NetmodeID.MultiplayerClient) return dashState == DashState.Done;
 
         // Phantom Dashes
         if (AttackManager.AiTimer == dashAtTime)
@@ -474,7 +500,7 @@ public class EoC : AcidicNPCOverride
             eye2.timeLeft = dashLength;
         }
 
-        return isDone;
+        return dashState == DashState.Done;
     }
 
     private bool Attack_PhantomCrossDash()
@@ -688,7 +714,15 @@ public class EoC : AcidicNPCOverride
     private bool Attack_TeleportBehind()
     {
         var target = Main.player[Npc.target].Center;
+        var targetVel = Main.player[Npc.target].velocity;
         var destination = target - (Npc.Center - target); // Opposite side of player
+
+        // Set a limit to how close the eye can be after teleporting
+        if (destination.Distance(target + targetVel * 15) <= 250)
+        {
+            destination = -target.DirectionTo(Npc.Center) * 250;
+            destination += target;
+        }
         Teleport(destination);
 
         return true;

--- a/Content/Bosses/EoC/EoC.cs
+++ b/Content/Bosses/EoC/EoC.cs
@@ -635,6 +635,7 @@ public class EoC : AcidicNPCOverride
         ref var dashes = ref Npc.localAI[0];
         ref var originX = ref Npc.localAI[1];
         ref var originY = ref Npc.localAI[2];
+        ref var startAngle = ref Npc.localAI[3];
 
         Attack_Hover(10f, 0.05f, 400f);
         var isDone = dashes > dashesPerSpin * spins;
@@ -650,10 +651,12 @@ public class EoC : AcidicNPCOverride
             var origin = Main.player[Npc.target].Center;
             originX = origin.X;
             originY = origin.Y;
+
+            startAngle = Main.player[Npc.target].velocity.ToRotation() + MathHelper.PiOver2;
         }
 
         var targetPos = new Vector2(originX, originY);
-        var rot = dashes * (MathHelper.Pi / dashesPerSpin);
+        var rot = (dashes * (MathHelper.Pi / dashesPerSpin)) + startAngle;
         var offsetFromPlayer = new Vector2(1000, 0).RotatedBy(rot);
         var pos = targetPos + offsetFromPlayer;
         var pos2 = targetPos - offsetFromPlayer;

--- a/Content/Bosses/KingSlime/KingSlime.cs
+++ b/Content/Bosses/KingSlime/KingSlime.cs
@@ -583,7 +583,17 @@ public class KingSlime : AcidicNPCOverride
         {
             case >= 0 and < 60: // Indicate While Tracking
                 teleportDestination = Main.player[npc.target].position;
+               
                 teleportDestination.Y -= 256;
+
+                // Check if player is under a block
+                var ground = Utilities.FindGroundVertical(teleportDestination.ToTileCoordinates()).ToWorldCoordinates();
+                if (ground.Y < Main.player[npc.target].position.Y)
+                {
+                    // Teleport on top of the player otherwise
+                    teleportDestination.Y = Main.player[npc.target].position.Y;
+                }
+                
                 IndicationDust();
                 break;
             case >= 60 and < 90: // Keep indicating while shrinking

--- a/Content/Bosses/Skeletron/SkeletronHead.cs
+++ b/Content/Bosses/Skeletron/SkeletronHead.cs
@@ -288,7 +288,7 @@ public class SkeletronHead : AcidicNPCOverride
     {
         var target = Main.player[Npc.target];
         var goal = target.Center;
-        goal.Y -= 400;
+        goal.Y -= 250;
 
         Npc.SimpleFlyMovement(Npc.DirectionTo(goal) * 10f, 0.5f);
 
@@ -303,7 +303,7 @@ public class SkeletronHead : AcidicNPCOverride
     {
         var target = Main.player[Npc.target];
         var goal = target.Center;
-        goal.Y -= 400;
+        goal.Y -= 250;
 
         // Aggressive lerp
         Npc.velocity = Vector2.Lerp(Npc.velocity, Vector2.Zero, 0.075f);

--- a/Content/Bosses/WoF/AI/WoF.cs
+++ b/Content/Bosses/WoF/AI/WoF.cs
@@ -44,6 +44,8 @@ public class WoF : AcidicNPCOverride
     public override bool ModifyCollisionData(NPC npc, Rectangle victimHitbox, ref int immunityCooldownSlot,
         ref MultipliableFloat damageMultiplier, ref Rectangle npcHitbox)
     {
+        if (!ShouldOverride()) return true;
+        
         damageMultiplier *= 0f;
         npcHitbox = new Rectangle();
         return false;

--- a/Content/Bosses/WoF/AI/WoF.cs
+++ b/Content/Bosses/WoF/AI/WoF.cs
@@ -22,8 +22,6 @@ public class WoF : AcidicNPCOverride
     protected override int OverriddenNpc => NPCID.WallofFlesh;
     protected override bool BossEnabled => BossToggleConfig.Get().EnableWallOfFlesh;
 
-    private int damage = 50;
-
     public float WallDistance
     {
         get => Npc.ai[3];
@@ -39,9 +37,16 @@ public class WoF : AcidicNPCOverride
     public override void SetDefaults(NPC entity)
     {
         if (!ShouldOverride()) return;
-        entity.damage = 0;
         entity.dontTakeDamage = true;
         entity.ShowNameOnHover = false;
+    }
+
+    public override bool ModifyCollisionData(NPC npc, Rectangle victimHitbox, ref int immunityCooldownSlot,
+        ref MultipliableFloat damageMultiplier, ref Rectangle npcHitbox)
+    {
+        damageMultiplier *= 0f;
+        npcHitbox = new Rectangle();
+        return false;
     }
 
     public override void BossHeadSlot(NPC npc, ref int index)
@@ -67,8 +72,6 @@ public class WoF : AcidicNPCOverride
         ]);
         AttackManager.Reset();
         WallDistance = 3000;
-        
-        damage = Npc.GetAttackDamage_ScaledByStrength(damage);
 
         Main.wofNPCIndex = Npc.whoAmI;
         Main.wofDrawAreaBottom = -1;
@@ -661,7 +664,7 @@ public class WoF : AcidicNPCOverride
     private Projectile NewFireball(Vector2 pos, Vector2 vel)
     {
         var proj = ProjHelper.NewUnscaledProjectile(Npc.GetSource_FromAI(), pos, vel, 
-            ProjectileID.CursedFlameHostile, damage / 2, 3);
+            ProjectileID.CursedFlameHostile, Npc.damage / 2, 3);
         proj.scale = 0.9f;
         proj.tileCollide = false;
         return proj;
@@ -669,14 +672,14 @@ public class WoF : AcidicNPCOverride
     
     private Projectile NewLaser(Vector2 pos, Vector2 vel, float rotation, int lifetime, int anchor = -1)
     {
-        var proj = BaseLineProjectile.Create<WoFLaser>(Npc.GetSource_FromAI(), pos, vel, damage / 2, 3, rotation, lifetime, anchor);
+        var proj = BaseLineProjectile.Create<WoFLaser>(Npc.GetSource_FromAI(), pos, vel, Npc.damage / 2, 3, rotation, lifetime, anchor);
 
         return proj;
     }
 
     private Projectile NewDeathray(Vector2 pos, float rotation, int lifetime, int anchor = -1)
     {
-        return DeathrayBase.Create<WoFDeathray>(Npc.GetSource_FromAI(), pos, (int) (damage * 1.5f), 5, rotation, lifetime, anchor);
+        return DeathrayBase.Create<WoFDeathray>(Npc.GetSource_FromAI(), pos, (int) (Npc.damage * 1.5f), 5, rotation, lifetime, anchor);
     }
 
     private Projectile NewDeathrayIndicator(Vector2 pos, float rotation, int lifetime, int anchor = -1)

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 displayName = Acidic Boss Reworks
 author = AcidAssassin
-version = 0.1.1
+version = 0.1.2
 modReferences = Luminance
 includeSource = true
 homepage = https://github.com/EthanDunn05/AcidicBosses


### PR DESCRIPTION
# King Slime
- King Slime now teleports on the player if there are blocks above the player. This is to avoid players cheesing King Slime by sitting in a box.
- 
# Eye of Cthulhu
- The Eye of Cthulhu now backs away when trying to dash from too close to the player
	- Normal dashes: 300 pixels
	- Triple dashes: 500 pixels
- The Eye of Cthulhu now cannot teleport within 250 pixels of the player
- The Eye of Cthulhu's triple dash now has a larger spread: 30 -> 36 degrees
- The Eye of Cthulhu's spinning dash attack now starts perpendicular to the player's movement to smoothen the transition into the attack

# Brain of Cthulhu
- Fixed confusion effect lingering after the boss is killed

# Skeletron
- Skeletron now hovers closer to the player allowing whips and most melee weapons to hit Skeletron more easily: 400 -> 250 pixels

# Wall of Flesh
- Fixed damage not scaling properly in Journey mode
- Overall increased damage